### PR TITLE
fix(auth): Prevent user logout on page reload

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,16 +1,16 @@
 import { Routes, Route } from 'react-router-dom';
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect } from 'react';
 import Navbar from './components/Navbar';
-import authService, { getCurrentUser } from './services/authService';
+import { UserContext } from './contexts/UserContext';
+import authService from './services/authService';
 import axios from './axios';
-import { pingBackend } from './services/pingService';
 import HomePage from './pages/HomePage';
 import UserHomePage from './pages/UserHomePage';
 import { Navigate } from 'react-router-dom';
 import FriendsPage from './pages/FriendsPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
-import CreatePostPage from './pages/CreatePostPage'; // Changed from SubmitIdeaPage
+import CreatePostPage from './pages/CreatePostPage';
 import LandingPage from './pages/LandingPage';
 import UserDashboard from './pages/UserDashboard';
 import ChatPage from './pages/ChatPage';
@@ -19,23 +19,14 @@ const AboutPage = () => <div style={{padding: 40}}><h2>About Us</h2><p>Info abou
 const ProfilePage = () => <div style={{padding: 40}}><h2>Your Profile</h2><p>Profile details here.</p></div>;
 
 function App() {
-  const [user, setUser] = useState(() => getCurrentUser());
+  const { user } = useContext(UserContext);
 
   useEffect(() => {
-    // Restore user state from localStorage on every load
-    const storedUser = getCurrentUser();
-    if (storedUser) {
-      setUser(storedUser);
+    const token = authService.getToken();
+    if (token) {
+      axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
     }
-    // On app load, ping backend. If unavailable, log out user.
-    (async () => {
-      const ok = await pingBackend();
-      if (!ok) {
-        authService.logout();
-        setUser(null);
-      }
-    })();
-  }, []);
+  }, [user]);
 
   return (
     <div>
@@ -46,7 +37,7 @@ function App() {
         <Route path="/feed" element={<HomePage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
-        <Route path="/create-post" element={<CreatePostPage />} /> {/* Changed path */}
+        <Route path="/create-post" element={<CreatePostPage />} />
         <Route path="/about" element={<AboutPage />} />
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/dashboard" element={<UserDashboard />} />

--- a/frontend/src/contexts/UserContext.jsx
+++ b/frontend/src/contexts/UserContext.jsx
@@ -1,21 +1,11 @@
-import { createContext, useState, useEffect } from 'react';
+import { createContext, useState } from 'react';
 import { getCurrentUser } from '../services/authService';
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const UserContext = createContext();
-
 
 const UserProvider = ({ children }) => {
   const [user, setUser] = useState(() => getCurrentUser());
-
-  useEffect(() => {
-    const syncUser = () => {
-      const storedUser = getCurrentUser();
-      setUser(storedUser);
-    };
-    window.addEventListener('storage', syncUser);
-    syncUser();
-    return () => window.removeEventListener('storage', syncUser);
-  }, []);
 
   return (
     <UserContext.Provider value={{ user, setUser }}>


### PR DESCRIPTION
This commit fixes an issue where the user would be logged out upon reloading the page. The fix involves the following changes:

- Refactored `App.jsx` to use the `UserContext` as the single source of truth for the user's authentication state.
- Removed the backend ping on application load, which was causing unnecessary logouts.
- Ensured the `Authorization` header is set for all Axios requests when the application loads with a valid token.
- Simplified `UserContext.jsx` to focus on its primary role of providing the user state.