### PR TITLE
fix(frontend): Correct adjacent JSX element error in PostCard

### DIFF
--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -1,10 +1,17 @@
 import { Card, CardHeader, Avatar, IconButton, CardContent, Typography, Box, CardActions } from '@mui/material';
 import ThumbUpOutlinedIcon from '@mui/icons-material/ThumbUpOutlined';
 import ShareIcon from '@mui/icons-material/Share';
+// eslint-disable-next-line no-unused-vars
+import { motion } from 'framer-motion';
 
 const PostCard = ({ post }) => {
   return (
-    <Card sx={{
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+    >
+      <Card sx={{
         mb: 3,
         borderRadius: 4,
         boxShadow: '0 4px 12px rgba(0,0,0,0.08)',

--- a/frontend/src/pages/UserDashboard.jsx
+++ b/frontend/src/pages/UserDashboard.jsx
@@ -31,6 +31,7 @@ import {
   PersonAdd,
   PostAdd,
 } from '@mui/icons-material';
+// eslint-disable-next-line no-unused-vars
 import { motion } from 'framer-motion';
 import { UserContext } from '../contexts/UserContext';
 
@@ -181,147 +182,147 @@ const UserDashboard = () => {
             </Paper>
           </Grid>
 
-        {/* Right Panel */}
-        </Grid>
-        <Grid item xs={12} md={8} lg={9}>
-          <Typography variant="h4" sx={{ mb: 4, fontWeight: 900, fontFamily: 'Cormorant Garamond, serif' }}>
-            Welcome back, {user?.username || 'User'}!
-          </Typography>
-          <Grid container spacing={4}>
-            {projects.map((proj, index) => (
-              <Grid item xs={12} sm={6} md={4} key={index}>
-                <Card
-                  elevation={5}
-                  sx={{
-                    borderRadius: 4,
-                    color: '#fff',
-                    background: proj.color,
-                    height: '100%',
-                  }}
-                >
-                  <CardContent>
-                    <Box display="flex" justifyContent="space-between" alignItems="center">
-                      <Typography variant="caption">{proj.date}</Typography>
-                      {proj.icon}
-                    </Box>
-                    <Typography variant="h6" sx={{ fontWeight: 700, my: 1 }}>{proj.title}</Typography>
-                    <Typography variant="body2" sx={{ mb: 2 }}>{proj.stage}</Typography>
-                    <Chip
-                      label={`${proj.daysLeft} Days Left`}
-                      size="small"
-                      sx={{ bgcolor: 'rgba(255, 255, 255, 0.3)', color: '#fff', fontWeight: 'bold' }}
-                    />
-                  </CardContent>
-                </Card>
-              </Grid>
-            ))}
-          </Grid>
-
-          <Grid container spacing={4} sx={{ mt: 2 }}>
-            <Grid item xs={12} lg={4}>
-                <Paper elevation={5} sx={{ p: 3, borderRadius: 4, bgcolor: '#ffffff' }}>
-                  <Typography variant="h6" sx={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 700, mb: 2 }}>Quick Stats</Typography>
-                  <Box display="flex" justifyContent="space-around">
-                    {quickStats.map(stat => (
-                      <Box key={stat.title} textAlign="center">
-                        <Typography variant="h5" sx={{ fontWeight: 700 }}>{stat.value}</Typography>
-                        <Typography variant="body2" color="text.secondary">{stat.title}</Typography>
+          {/* Right Panel */}
+          <Grid item xs={12} md={8} lg={9}>
+            <Typography variant="h4" sx={{ mb: 4, fontWeight: 900, fontFamily: 'Cormorant Garamond, serif' }}>
+              Welcome back, {user?.username || 'User'}!
+            </Typography>
+            <Grid container spacing={4}>
+              {projects.map((proj, index) => (
+                <Grid item xs={12} sm={6} md={4} key={index}>
+                  <Card
+                    elevation={5}
+                    sx={{
+                      borderRadius: 4,
+                      color: '#fff',
+                      background: proj.color,
+                      height: '100%',
+                    }}
+                  >
+                    <CardContent>
+                      <Box display="flex" justifyContent="space-between" alignItems="center">
+                        <Typography variant="caption">{proj.date}</Typography>
+                        {proj.icon}
                       </Box>
-                    ))}
-                  </Box>
-                </Paper>
+                      <Typography variant="h6" sx={{ fontWeight: 700, my: 1 }}>{proj.title}</Typography>
+                      <Typography variant="body2" sx={{ mb: 2 }}>{proj.stage}</Typography>
+                      <Chip
+                        label={`${proj.daysLeft} Days Left`}
+                        size="small"
+                        sx={{ bgcolor: 'rgba(255, 255, 255, 0.3)', color: '#fff', fontWeight: 'bold' }}
+                      />
+                    </CardContent>
+                  </Card>
+                </Grid>
+              ))}
             </Grid>
-            <Grid item xs={12} lg={4}>
-                <Paper elevation={5} sx={{ p: 3, borderRadius: 4, bgcolor: '#ffffff' }}>
-                  <Typography variant="h6" sx={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 700, mb: 2 }}>My Tech Stack</Typography>
-                  <Box display="flex" flexWrap="wrap" gap={1}>
-                    {techStack.map(skill => (
-                      <Chip key={skill} label={skill} sx={{ bgcolor: '#eef2f7', fontWeight: 'bold' }} />
-                    ))}
-                  </Box>
-                </Paper>
-            </Grid>
-            <Grid item xs={12} lg={4}>
-                <Paper elevation={5} sx={{ p: 3, borderRadius: 4, bgcolor: '#ffffff' }}>
-                  <Typography variant="h6" sx={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 700, mb: 2 }}>To-Do List</Typography>
-                  <List dense>
-                    {todoList.map(item => (
-                      <ListItem key={item.task} dense>
-                        <ListItemText primary={item.task} sx={{ textDecoration: item.done ? 'line-through' : 'none' }} />
-                      </ListItem>
-                    ))}
-                  </List>
-                </Paper>
-            </Grid>
-          </Grid>
 
-          <Grid container spacing={4} sx={{ mt: 2 }}>
-            <Grid item xs={12} lg={7}>
-                <Paper elevation={5} sx={{ p: 3, borderRadius: 4, bgcolor: '#ffffff' }}>
-                  <Box display="flex" justifyContent="space-between" alignItems="center">
-                    <Typography variant="h6" sx={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 700 }}>Notifications</Typography>
-                    <IconButton onClick={() => setShowInbox(!showInbox)}>
-                      {showInbox ? <ExpandLess /> : <ExpandMore />}
-                    </IconButton>
-                  </Box>
-                  <Collapse in={showInbox}>
-                    <Box display="flex" flexDirection="column" gap={2} mt={2}>
-                      {dummyMessages.map((msg, i) => (
-                        <Box
-                          key={i}
-                          display="flex"
-                          gap={2}
-                          alignItems="center"
-                          p={2}
-                          bgcolor={i === 1 ? '#111' : '#f0f2f5'}
-                          color={i === 1 ? '#fff' : '#000'}
-                          borderRadius={2}
-                        >
-                          <Avatar src={msg.avatar} sx={{ width: 40, height: 40 }} />
-                          <Box>
-                            <Typography fontWeight="bold" sx={{ fontSize: '0.95rem' }}>{msg.sender}</Typography>
-                            <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>{msg.message}</Typography>
-                          </Box>
+            <Grid container spacing={4} sx={{ mt: 2 }}>
+              <Grid item xs={12} lg={4}>
+                  <Paper elevation={5} sx={{ p: 3, borderRadius: 4, bgcolor: '#ffffff' }}>
+                    <Typography variant="h6" sx={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 700, mb: 2 }}>Quick Stats</Typography>
+                    <Box display="flex" justifyContent="space-around">
+                      {quickStats.map(stat => (
+                        <Box key={stat.title} textAlign="center">
+                          <Typography variant="h5" sx={{ fontWeight: 700 }}>{stat.value}</Typography>
+                          <Typography variant="body2" color="text.secondary">{stat.title}</Typography>
                         </Box>
                       ))}
                     </Box>
-                  </Collapse>
-                </Paper>
+                  </Paper>
+              </Grid>
+              <Grid item xs={12} lg={4}>
+                  <Paper elevation={5} sx={{ p: 3, borderRadius: 4, bgcolor: '#ffffff' }}>
+                    <Typography variant="h6" sx={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 700, mb: 2 }}>My Tech Stack</Typography>
+                    <Box display="flex" flexWrap="wrap" gap={1}>
+                      {techStack.map(skill => (
+                        <Chip key={skill} label={skill} sx={{ bgcolor: '#eef2f7', fontWeight: 'bold' }} />
+                      ))}
+                    </Box>
+                  </Paper>
+              </Grid>
+              <Grid item xs={12} lg={4}>
+                  <Paper elevation={5} sx={{ p: 3, borderRadius: 4, bgcolor: '#ffffff' }}>
+                    <Typography variant="h6" sx={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 700, mb: 2 }}>To-Do List</Typography>
+                    <List dense>
+                      {todoList.map(item => (
+                        <ListItem key={item.task} dense>
+                          <ListItemText primary={item.task} sx={{ textDecoration: item.done ? 'line-through' : 'none' }} />
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Paper>
+              </Grid>
             </Grid>
-            <Grid item xs={12} lg={5}>
-                <Paper elevation={5} sx={{ p: 3, borderRadius: 4, bgcolor: '#ffffff' }}>
-                  <Typography variant="h6" sx={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 700, mb: 2 }}>
-                    Calendar - March
-                  </Typography>
-                  <Box display="grid" gridTemplateColumns="repeat(7, 1fr)" gap={1} textAlign="center">
-                    {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map(day => <Typography key={day} variant="caption" color="text.secondary">{day}</Typography>)}
-                    {Array.from({ length: 31 }, (_, i) => {
-                      const isMarked = [5, 8, 12, 21].includes(i + 1);
-                      return (
-                        <Box
-                          key={i}
-                          p={1}
-                          borderRadius="50%"
-                          bgcolor={isMarked ? '#38bdf8' : 'transparent'}
-                          color={isMarked ? '#fff' : '#000'}
-                          sx={{
-                            transition: 'all 0.2s ease',
-                            '&:hover': {
-                              bgcolor: isMarked ? '#38bdf8' : '#e0e0e0',
-                              transform: 'scale(1.1)'
-                            }
-                          }}
-                        >
-                          {i + 1}
-                        </Box>
-                      );
-                    })}
-                  </Box>
-                </Paper>
+
+            <Grid container spacing={4} sx={{ mt: 2 }}>
+              <Grid item xs={12} lg={7}>
+                  <Paper elevation={5} sx={{ p: 3, borderRadius: 4, bgcolor: '#ffffff' }}>
+                    <Box display="flex" justifyContent="space-between" alignItems="center">
+                      <Typography variant="h6" sx={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 700 }}>Notifications</Typography>
+                      <IconButton onClick={() => setShowInbox(!showInbox)}>
+                        {showInbox ? <ExpandLess /> : <ExpandMore />}
+                      </IconButton>
+                    </Box>
+                    <Collapse in={showInbox}>
+                      <Box display="flex" flexDirection="column" gap={2} mt={2}>
+                        {dummyMessages.map((msg, i) => (
+                          <Box
+                            key={i}
+                            display="flex"
+                            gap={2}
+                            alignItems="center"
+                            p={2}
+                            bgcolor={i === 1 ? '#111' : '#f0f2f5'}
+                            color={i === 1 ? '#fff' : '#000'}
+                            borderRadius={2}
+                          >
+                            <Avatar src={msg.avatar} sx={{ width: 40, height: 40 }} />
+                            <Box>
+                              <Typography fontWeight="bold" sx={{ fontSize: '0.95rem' }}>{msg.sender}</Typography>
+                              <Typography variant="body2" sx={{ fontSize: '0.85rem' }}>{msg.message}</Typography>
+                            </Box>
+                          </Box>
+                        ))}
+                      </Box>
+                    </Collapse>
+                  </Paper>
+              </Grid>
+              <Grid item xs={12} lg={5}>
+                  <Paper elevation={5} sx={{ p: 3, borderRadius: 4, bgcolor: '#ffffff' }}>
+                    <Typography variant="h6" sx={{ fontFamily: 'Cormorant Garamond, serif', fontWeight: 700, mb: 2 }}>
+                      Calendar - March
+                    </Typography>
+                    <Box display="grid" gridTemplateColumns="repeat(7, 1fr)" gap={1} textAlign="center">
+                      {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map(day => <Typography key={day} variant="caption" color="text.secondary">{day}</Typography>)}
+                      {Array.from({ length: 31 }, (_, i) => {
+                        const isMarked = [5, 8, 12, 21].includes(i + 1);
+                        return (
+                          <Box
+                            key={i}
+                            p={1}
+                            borderRadius="50%"
+                            bgcolor={isMarked ? '#38bdf8' : 'transparent'}
+                            color={isMarked ? '#fff' : '#000'}
+                            sx={{
+                              transition: 'all 0.2s ease',
+                              '&:hover': {
+                                bgcolor: isMarked ? '#38bdf8' : '#e0e0e0',
+                                transform: 'scale(1.1)'
+                              }
+                            }}
+                          >
+                            {i + 1}
+                          </Box>
+                        );
+                      })}
+                    </Box>
+                  </Paper>
+              </Grid>
             </Grid>
           </Grid>
         </Grid>
-      </Grid>
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
This commit fixes a JSX parsing error in the `PostCard` component that was caused by a missing opening `<motion.div>` tag and an extraneous closing tag. The error 'Adjacent JSX elements must be wrapped in an enclosing tag' was being thrown because the component was returning a `<Card>` element followed by an unrelated closing `</motion.div>`.

I have corrected the structure by wrapping the `Card` component in a `<motion.div>` and adding the necessary import from `framer-motion`. I also added a simple fade-in animation to the card, which appears to have been the original intent.

Additionally, I discovered and fixed a pre-existing JSX parsing error in the `UserDashboard` component. The component had an improperly nested `Grid` layout and a missing closing `</Box>` tag. I have corrected the layout and added the missing tag to ensure the component renders correctly.

Finally, I addressed a 'no-unused-vars' linting error for the `motion` import in both `PostCard.jsx` and `UserDashboard.jsx` by adding an `eslint-disable-next-line` comment. This was necessary because the linter was not correctly identifying the usage of `motion` in the JSX.